### PR TITLE
Separating the json theme object into 2 theme files dark/light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# HEAD
+
+- Separating the themes (dark, light) into separate json objects.
+
 # 0.1.2
 
 - Fixing: Ace adapter would error if build didn't exist yet.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Clone this repository and after `npm install`. Run
 $ npm run build
 ```
 
-This will run the script that will build all the themes.
+This will run the script that will build all the themes. The themes are built from the `json` files in the `lib/themes` folder.
 
 ## Adapters
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,10 @@
-const theme    = require("./lib/theme")
+const themes   = require("./lib/themes")
 const adapters = require("./lib/adapters")
 const _        = require("lodash")
 
-_.map({
-    "light": "GitHub Light",
-    "dark": "GitHub Dark"
-  }, (name, variation) => {
+themes.map(theme => {
   Object.keys(adapters).map( k => {
     const adapter = adapters[k]
-    adapter.call(this, JSON.parse(JSON.stringify(theme)), variation, name)
+    adapter.call(this, theme)
   })
 })

--- a/lib/adapters/ace.js
+++ b/lib/adapters/ace.js
@@ -1,22 +1,24 @@
 const exec = require("child_process").exec
 const mkdirp = require("mkdirp")
 const fs = require("fs")
+const header = require("../utils").header
 
-module.exports = (theme, variation, name) => {
+module.exports = (theme) => {
   mkdirp.sync("build/ace")
-  fs.exists("build/ace/github-" + variation + ".css", exists => {
+  fs.exists("build/ace/" + theme.filename + ".css", exists => {
     if(exists) {
-      fs.unlink("build/ace/github-" + variation + ".css")
+      fs.unlink("build/ace/" + theme.filename + ".css")
     }
   })
-  exec("node node_modules/ace/tool/tmtheme.js github-" + variation + " \"build/tmtheme/" + name + ".tmbundle/Themes/" + name + ".tmTheme\" build/ace", (error, stdout, stderr) => {
+  exec("node node_modules/ace/tool/tmtheme.js " + theme.filename + " \"build/tmtheme/" + theme.name + ".tmbundle/Themes/" + theme.name + ".tmTheme\" build/ace", (error, stdout, stderr) => {
     if (error) {
       throw error;
     }
-    var css = fs.readFileSync("build/ace/github-" + variation + ".css")
-    var reg = new RegExp("\\.ace\-github\-" + variation + " ?\\.", "gi")
+    var css = fs.readFileSync("build/ace/" + theme.filename + ".css")
+    var reg = new RegExp("\\.ace\-" + theme.filename + " ?\\.", "gi")
     css = css.toString().replace(reg, ".")
-    fs.writeFileSync("build/ace/github-" + variation + ".css", css)
-    fs.unlink("build/ace/github-" + variation + ".js")
+    css = header(theme) + css
+    fs.writeFileSync("build/ace/" + theme.filename + ".css", css)
+    fs.unlink("build/ace/" + theme.filename + ".js")
   });
 }

--- a/lib/adapters/atom.js
+++ b/lib/adapters/atom.js
@@ -1,9 +1,9 @@
 const exec = require("child_process").exec
 const mkdirp = require("mkdirp")
 
-module.exports = (theme, variation, name) => {
+module.exports = (theme) => {
   mkdirp.sync("build/atom")
-  exec("apm init --theme build/atom/github-" + variation + " --convert \"build/tmtheme/" + name + ".tmbundle/Themes/" + name + ".tmTheme\"", (error, stdout, stderr) => {
+  exec("apm init --theme build/atom/" + theme.filename + " --convert \"build/tmtheme/" + theme.name + ".tmbundle/Themes/" + theme.name + ".tmTheme\"", (error, stdout, stderr) => {
     if (error) {
       throw error;
     }

--- a/lib/adapters/css.js
+++ b/lib/adapters/css.js
@@ -1,11 +1,11 @@
 const fs = require("fs")
 const _  = require("lodash")
 const mkdirp = require("mkdirp")
+const header = require("../utils").header
 
-module.exports = (theme, variation, name) => {
-  const license = fs.readFileSync("LICENSE")
+module.exports = (theme) => {
 
-  theme = _.filter(theme.settings, t => { return t["scope"] != null })
+  var settings = _.filter(theme.settings, t => { return t["scope"] != null })
 
   var convertAttributes = a => {
     var attributes = {}
@@ -50,8 +50,8 @@ module.exports = (theme, variation, name) => {
       classes = [],
       classesByScope = {}
 
-  theme.map( t => {
-    var style = convertAttributes(_.assign({}, t.settings, t["settings-" + variation]))
+  settings.map( t => {
+    var style = convertAttributes(t.settings)
 
     var selectors = t.scope.split(",").map( s => { return s.trim() })
     if (selectors.length != 0 && selectors != ["none"]) {
@@ -102,7 +102,7 @@ module.exports = (theme, variation, name) => {
     }
   })
 
-  var output = "/*\n" + license + "\n*/\n\n"
+  var output = header(theme)
   rules.map(rule => {
     if (Object.keys(rule.style).length != 0) {
       output += rule.selectors.map( selector => {
@@ -114,6 +114,6 @@ module.exports = (theme, variation, name) => {
     }
   })
   mkdirp.sync("build/css")
-  fs.writeFileSync("build/css/github-" + variation + ".map.json", JSON.stringify(classesByScope))
-  fs.writeFileSync("build/css/github-" + variation + ".css", output)
+  fs.writeFileSync("build/css/" + theme.filename + ".map.json", JSON.stringify(classesByScope))
+  fs.writeFileSync("build/css/" + theme.filename + ".css", output)
 }

--- a/lib/adapters/tmtheme.js
+++ b/lib/adapters/tmtheme.js
@@ -3,26 +3,9 @@ const plist = require("plist")
 const _ = require("lodash")
 const mkdirp = require("mkdirp")
 
-module.exports = (theme, variation, name) => {
-  var selectVariant = (hash, variant) => {
-    hash = Object.assign({}, hash)
-
-    if (hash.settings) {
-      hash.settings = Object.assign(hash.settings, hash["settings-" + variant])
-    }
-
-    Object.keys(hash).map( k => {
-      if (k.match(/^settings\-/)) {
-        delete hash[k]
-      } else {
-        hash[k] = (typeof hash[k] === "object" ? selectVariant(hash[k], variant) : hash[k])
-      }
-    })
-    return hash
-  }
-  theme.settings = theme.settings.map( s => { return selectVariant(s, variation) })
+module.exports = (theme) => {
   var output = plist.build(theme)
-  var dir = "build/tmtheme/" + name + ".tmbundle/Themes/"
+  var dir = "build/tmtheme/" + theme.name + ".tmbundle/Themes/"
   mkdirp.sync(dir)
-  fs.writeFileSync(dir + name + ".tmTheme", output)
+  fs.writeFileSync(dir + theme.name + ".tmTheme", output)
 }

--- a/lib/themes/dark.json
+++ b/lib/themes/dark.json
@@ -1,0 +1,291 @@
+{
+  "author" : "GitHub",
+  "settings" : [
+    {
+      "settings" : {
+        "background" : "#20272b",
+        "foreground" : "#ddd",
+        "lineHighlight": "#464a4d",
+        "invisibles" : "#6e7880",
+        "selection": "#832563",
+        "caret": "#fff"
+      }
+    },
+    {
+      "scope" : "comment",
+      "settings" : {
+        "foreground" : "#969896"
+      },
+      "name" : "Comment"
+    },
+    {
+      "scope" : "constant, variable.other.constant",
+      "settings" : {
+        "foreground" : "#0099cd"
+      },
+      "name" : "Constant"
+    },
+    {
+      "scope" : "keyword.operator.symbole, keyword.other.mark",
+      "name": "Clojure workaround; don't highlight these separately from their enclosing scope",
+      "settings": {}
+    },
+    {
+      "scope" : "entity, entity.name",
+      "settings" : {
+        "fontStyle" : "",
+        "foreground" : "#9774cb"
+      },
+      "name" : "Entity"
+    },
+    {
+      "scope": "variable.parameter.function",
+      "settings" : {
+        "foreground" : "#ddd"
+      }
+    },
+    {
+      "scope": "entity.name.tag",
+      "settings" : {
+        "fontStyle" : "",
+        "foreground" : "#7bcc72"
+      }
+    },
+    {
+      "scope" : "keyword",
+      "settings" : {
+        "fontStyle" : "",
+        "foreground" : "#cc2372"
+      },
+      "name" : "Keyword"
+    },
+    {
+      "scope" : "storage, storage.type",
+      "settings" : {
+        "foreground" : "#cc2372"
+      },
+      "name" : "Storage"
+    },
+    {
+      "scope": "storage.modifier.package, storage.modifier.import, storage.type.java",
+      "settings" : {
+        "foreground" : "#ddd"
+      }
+    },
+    {
+      "scope" : "string, punctuation.definition.string, string punctuation.section.embedded source",
+      "settings" : {
+        "fontStyle" : "",
+        "foreground" : "#3c66e2"
+      },
+      "name" : "String"
+    },
+    {
+      "name": "Ada workaround; don't highlight imports as strings",
+      "scope": "string.unquoted.import.ada",
+      "settings": {}
+    },
+    {
+      "scope" : "support",
+      "settings" : {
+        "fontStyle" : "",
+        "foreground" : "#0099cd"
+      },
+      "name" : "Support"
+    },
+    {
+      "scope": "meta.property-name",
+      "settings" : {
+        "fontStyle" : "",
+        "foreground" : "#0099cd"
+      }
+    },
+    {
+      "scope" : "variable",
+      "settings" : {
+        "fontStyle" : "",
+        "foreground" : "#fb8764"
+      },
+      "name" : "Variable"
+    },
+    {
+      "scope": "variable.other",
+      "settings" : {
+        "foreground" : "#ddd"
+      }
+    },
+    {
+      "scope" : "invalid.deprecated",
+      "settings" : {
+        "fontStyle" : "bold italic underline",
+        "foreground" : "#e63525"
+      },
+      "name" : "Invalid – Deprecated"
+    },
+    {
+      "scope" : "invalid.illegal",
+      "settings" : {
+        "fontStyle" : "italic underline",
+        "foreground" : "#f8f8f8",
+        "background" : "#e63525"
+      },
+      "name" : "Invalid – Illegal"
+    },
+    {
+      "scope" : "string source",
+      "settings" : {
+        "fontStyle" : "",
+        "foreground" : "#ddd"
+      },
+      "name" : "String embedded-source"
+    },
+    {
+      "scope" : "string variable",
+      "settings" : {
+        "fontStyle" : "",
+        "foreground" : "#0099cd"
+      },
+      "name" : "String variable"
+    },
+    {
+      "scope" : "string.regexp",
+      "settings" : {
+        "fontStyle" : "",
+        "foreground" : "#3c66e2"
+      },
+      "name" : "String.regexp"
+    },
+    {
+      "scope" : "string.regexp.character-class, string.regexp constant.character.escape, string.regexp source.ruby.embedded, string.regexp string.regexp.arbitrary-repitition",
+      "settings" : {
+        "foreground" : "#3c66e2"
+      },
+      "name" : "String.regexp.«special»"
+    },
+    {
+      "scope" : "string.regexp constant.character.escape",
+      "settings" : {
+        "fontStyle" : "bold",
+        "foreground" : "#7bcc72"
+      },
+      "name" : "String.regexp constant.character.escape"
+    },
+    {
+      "scope" : "support.constant",
+      "settings" : {
+        "fontStyle" : "",
+        "foreground" : "#0099cd"
+      },
+      "name" : "Support.constant"
+    },
+    {
+      "scope" : "support.variable",
+      "settings" : {
+        "foreground" : "#0099cd"
+      },
+      "name" : "Support.variable"
+    },
+    {
+      "scope": "meta.module-reference",
+      "settings" : {
+        "foreground" : "#0099cd"
+      },
+      "name": "meta module-reference"
+    },
+    {
+      "scope" : "markup.list",
+      "settings" : {
+        "foreground" : "#c26b2b"
+      },
+      "name" : "Markup.list"
+    },
+    {
+      "scope" : "markup.heading, markup.heading entity.name",
+      "settings" : {
+        "fontStyle" : "bold",
+        "foreground" : "#264ec5"
+      },
+      "name" : "Markup.heading"
+    },
+    {
+      "scope" : "markup.quote",
+      "settings" : {
+        "foreground" : "#00acac"
+      },
+      "name" : "Markup.quote"
+    },
+    {
+      "scope" : "markup.italic",
+      "settings" : {
+        "fontStyle" : "italic",
+        "foreground" : "#ddd"
+      },
+      "name" : "Markup.italic"
+    },
+    {
+      "scope" : "markup.bold",
+      "settings" : {
+        "fontStyle" : "bold",
+        "foreground" : "#ddd"
+      },
+      "name" : "Markup.bold"
+    },
+    {
+      "scope" : "markup.raw",
+      "settings" : {
+        "fontStyle" : "",
+        "foreground" : "#0099cd"
+      },
+      "name" : "Markup.raw"
+    },
+    {
+      "scope" : "markup.deleted, meta.diff.header.from-file",
+      "settings" : {
+        "background": "#ffecec",
+        "foreground" : "#bd2c00"
+      },
+      "name" : "Markup.deleted"
+    },
+    {
+      "scope": "markup.inserted, meta.diff.header.to-file",
+      "settings" : {
+        "background": "#eaffea",
+        "foreground" : "#55a532"
+      },
+      "name" : "Markup.inserted"
+    },
+    {
+      "scope": "meta.diff.range",
+      "settings" : {
+        "fontStyle": "bold",
+        "foreground" : "#9774cb"
+      }
+    },
+    {
+      "scope": "meta.diff.header",
+      "settings" : {
+        "foreground" : "#0099cd"
+      }
+    },
+    {
+      "scope" : "meta.separator",
+      "settings" : {
+        "fontStyle" : "bold",
+        "foreground": "#264ec5"
+      },
+      "name" : "Meta.separator"
+    },
+    {
+      "name": "Output",
+      "scope": "meta.output",
+      "settings" : {
+        "foreground": "#264ec5"
+      }
+    }
+  ],
+  "comment" : "GitHub Dark syntax theme",
+  "name" : "GitHub Dark",
+  "semanticClass" : "theme.dark.github",
+  "filename": "github-dark",
+  "uuid": "C8E24EAE-6212-41E3-AC1A-F49362B6150D"
+}

--- a/lib/themes/index.js
+++ b/lib/themes/index.js
@@ -1,0 +1,7 @@
+const dark  = require("./dark")
+const light = require("./light")
+
+module.exports = [
+  dark,
+  light
+]

--- a/lib/themes/light.json
+++ b/lib/themes/light.json
@@ -1,4 +1,4 @@
-module.exports = {
+{
   "author" : "GitHub",
   "settings" : [
     {
@@ -9,14 +9,6 @@ module.exports = {
         "foreground" : "#333",
         "invisibles" : "#c0c0c0",
         "caret" : "#000"
-      },
-      "settings-dark" : {
-        "background" : "#20272b",
-        "foreground" : "#ddd",
-        "lineHighlight": "#464a4d",
-        "invisibles" : "#6e7880",
-        "selection": "#832563",
-        "caret": "#fff"
       }
     },
     {
@@ -31,9 +23,6 @@ module.exports = {
       "settings" : {
         "foreground" : "#0086b3"
       },
-      "settings-dark" : {
-        "foreground" : "#0099cd"
-      },
       "name" : "Constant"
     },
     {
@@ -47,18 +36,12 @@ module.exports = {
         "fontStyle" : "",
         "foreground" : "#795da3"
       },
-      "settings-dark" : {
-        "foreground" : "#9774cb"
-      },
       "name" : "Entity"
     },
     {
       "scope": "variable.parameter.function",
       "settings" : {
         "foreground" : "#333"
-      },
-      "settings-dark" : {
-        "foreground" : "#ddd"
       }
     },
     {
@@ -66,9 +49,6 @@ module.exports = {
       "settings" : {
         "fontStyle" : "",
         "foreground" : "#63a35c"
-      },
-      "settings-dark" : {
-        "foreground" : "#7bcc72"
       }
     },
     {
@@ -77,9 +57,6 @@ module.exports = {
         "fontStyle" : "",
         "foreground" : "#a71d5d"
       },
-      "settings-dark" : {
-        "foreground" : "#cc2372"
-      },
       "name" : "Keyword"
     },
     {
@@ -87,18 +64,12 @@ module.exports = {
       "settings" : {
         "foreground" : "#a71d5d"
       },
-      "settings-dark" : {
-        "foreground" : "#cc2372"
-      },
       "name" : "Storage"
     },
     {
       "scope": "storage.modifier.package, storage.modifier.import, storage.type.java",
       "settings": {
         "foreground": "#333"
-      },
-      "settings-dark" : {
-        "foreground" : "#ddd"
       }
     },
     {
@@ -106,9 +77,6 @@ module.exports = {
       "settings" : {
         "fontStyle" : "",
         "foreground" : "#183691"
-      },
-      "settings-dark" : {
-        "foreground" : "#3c66e2"
       },
       "name" : "String"
     },
@@ -123,9 +91,6 @@ module.exports = {
         "fontStyle" : "",
         "foreground" : "#0086b3"
       },
-      "settings-dark" : {
-        "foreground" : "#0099cd"
-      },
       "name" : "Support"
     },
     {
@@ -133,9 +98,6 @@ module.exports = {
       "settings" : {
         "fontStyle" : "",
         "foreground" : "#0086b3"
-      },
-      "settings-dark" : {
-        "foreground" : "#0099cd"
       }
     },
     {
@@ -144,18 +106,12 @@ module.exports = {
         "fontStyle" : "",
         "foreground" : "#ed6a43"
       },
-      "settings-dark" : {
-        "foreground" : "#fb8764"
-      },
       "name" : "Variable"
     },
     {
       "scope": "variable.other",
       "settings": {
         "foreground": "#333"
-      },
-      "settings-dark" : {
-        "foreground" : "#ddd"
       }
     },
     {
@@ -163,9 +119,6 @@ module.exports = {
       "settings" : {
         "fontStyle" : "bold italic underline",
         "foreground" : "#b52a1d"
-      },
-      "settings-dark" : {
-        "foreground" : "#e63525"
       },
       "name" : "Invalid – Deprecated"
     },
@@ -176,9 +129,6 @@ module.exports = {
         "background" : "#b52a1d",
         "foreground" : "#f8f8f8"
       },
-      "settings-dark" : {
-        "background" : "#e63525"
-      },
       "name" : "Invalid – Illegal"
     },
     {
@@ -186,9 +136,6 @@ module.exports = {
       "settings" : {
         "fontStyle" : "",
         "foreground" : "#333"
-      },
-      "settings-dark" : {
-        "foreground" : "#ddd"
       },
       "name" : "String embedded-source"
     },
@@ -198,9 +145,6 @@ module.exports = {
         "fontStyle" : "",
         "foreground" : "#0086b3"
       },
-      "settings-dark" : {
-        "foreground" : "#0099cd"
-      },
       "name" : "String variable"
     },
     {
@@ -209,18 +153,12 @@ module.exports = {
         "fontStyle" : "",
         "foreground" : "#183691"
       },
-      "settings-dark" : {
-        "foreground" : "#3c66e2"
-      },
       "name" : "String.regexp"
     },
     {
       "scope" : "string.regexp.character-class, string.regexp constant.character.escape, string.regexp source.ruby.embedded, string.regexp string.regexp.arbitrary-repitition",
       "settings" : {
         "foreground" : "#183691"
-      },
-      "settings-dark" : {
-        "foreground" : "#3c66e2"
       },
       "name" : "String.regexp.«special»"
     },
@@ -230,9 +168,6 @@ module.exports = {
         "fontStyle" : "bold",
         "foreground" : "#63a35c"
       },
-      "settings-dark" : {
-        "foreground" : "#7bcc72"
-      },
       "name" : "String.regexp constant.character.escape"
     },
     {
@@ -241,18 +176,12 @@ module.exports = {
         "fontStyle" : "",
         "foreground" : "#0086b3"
       },
-      "settings-dark" : {
-        "foreground" : "#0099cd"
-      },
       "name" : "Support.constant"
     },
     {
       "scope" : "support.variable",
       "settings" : {
         "foreground" : "#0086b3"
-      },
-      "settings-dark" : {
-        "foreground" : "#0099cd"
       },
       "name" : "Support.variable"
     },
@@ -261,18 +190,12 @@ module.exports = {
       "settings" : {
         "foreground" : "#0086b3"
       },
-      "settings-dark" : {
-        "foreground" : "#0099cd"
-      },
       "name": "meta module-reference"
     },
     {
       "scope" : "markup.list",
       "settings" : {
         "foreground" : "#693a17"
-      },
-      "settings-dark" : {
-        "foreground" : "#c26b2b"
       },
       "name" : "Markup.list"
     },
@@ -282,18 +205,12 @@ module.exports = {
         "fontStyle" : "bold",
         "foreground" : "#1d3e81"
       },
-      "settings-dark" : {
-        "foreground" : "#264ec5"
-      },
       "name" : "Markup.heading"
     },
     {
       "scope" : "markup.quote",
       "settings" : {
         "foreground" : "#008080"
-      },
-      "settings-dark" : {
-        "foreground" : "#00acac"
       },
       "name" : "Markup.quote"
     },
@@ -303,9 +220,6 @@ module.exports = {
         "fontStyle" : "italic",
         "foreground" : "#333"
       },
-      "settings-dark" : {
-        "foreground" : "#ddd"
-      },
       "name" : "Markup.italic"
     },
     {
@@ -314,9 +228,6 @@ module.exports = {
         "fontStyle" : "bold",
         "foreground" : "#333"
       },
-      "settings-dark" : {
-        "foreground" : "#ddd"
-      },
       "name" : "Markup.bold"
     },
     {
@@ -324,9 +235,6 @@ module.exports = {
       "settings" : {
         "fontStyle" : "",
         "foreground" : "#0086b3"
-      },
-      "settings-dark" : {
-        "foreground" : "#0099cd"
       },
       "name" : "Markup.raw"
     },
@@ -351,18 +259,12 @@ module.exports = {
       "settings" : {
         "foreground" : "#795da3",
         "fontStyle": "bold"
-      },
-      "settings-dark" : {
-        "foreground" : "#9774cb"
       }
     },
     {
       "scope": "meta.diff.header",
       "settings" : {
         "foreground" : "#0086b3"
-      },
-      "settings-dark" : {
-        "foreground" : "#0099cd"
       }
     },
     {
@@ -371,9 +273,6 @@ module.exports = {
         "fontStyle" : "bold",
         "foreground" : "#1d3e81"
       },
-      "settings-dark" : {
-        "foreground": "#264ec5"
-      },
       "name" : "Meta.separator"
     },
     {
@@ -381,14 +280,12 @@ module.exports = {
       "scope": "meta.output",
       "settings": {
         "foreground": "#1d3e81"
-      },
-      "settings-dark" : {
-        "foreground": "#264ec5"
       }
     }
   ],
   "comment" : "GitHub Light syntax theme",
   "name" : "GitHub Light",
   "semanticClass" : "theme.light.github",
+  "filename": "github-light",
   "uuid": "A1C4DFA0-7031-11E4-9803-0800200C9A66"
 }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,0 +1,9 @@
+const package = require("../../package.json")
+
+module.exports.header = (theme) => {
+  return `/*!
+ * ${theme.name} v${package.version}
+ * Copyright (c) 2012 - ${new Date().getFullYear()} ${package.author}
+ * Licensed under MIT (https://github.com/primer/github-syntax-theme-generator/blob/master/LICENSE)
+ */\n\n`
+}


### PR DESCRIPTION
We were doing some tricky things to use one `json` object for both things. This was overcomplicated. I've separated out the two themes into separate json files. This makes things more straight forward and eliminates the need to enumerate on static arrays of variations and merge settings objects.

