### PR TITLE
Update themes to be more compatible with Sublime text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Accessibility contrast tests
 - Separating the themes (dark, light) into separate json objects.
+- Update themes to be more compatible with SublimeText
 
 # 0.1.2
 

--- a/lib/themes/dark.json
+++ b/lib/themes/dark.json
@@ -8,18 +8,34 @@
         "lineHighlight": "#464a4d",
         "invisibles" : "#6e7880",
         "selection": "#832563",
-        "caret": "#fff"
+        "caret": "#fff",
+        "inactiveSelection" : "#464a4d",
+        "selectionBorder" : "#464a4d",
+        "findHighlight" : "#fb8764",
+        "findHighlightForeground" : "#20272b",
+        "guide" : "#6e7880",
+        "activeGuide" : "#ddd",
+        "stackGuide" : "#828c93",
+        "highlight" : "#f5f5f5",
+        "popupCss" : "<![CDATA[html { background-color: #39464d; } h1, h2, h3, h4, h5, h6 { color: #264ec5; margin-top: 0.2em; margin-bottom: 0.2em; } h1 { font-size: 1.5em; } h2 { font-size: 1.4em; } h3 { font-size: 1.3em; } h4 { font-size: 1.2em; } h5 { font-size: 1.1em; } h6 { font-size: 1em; } blockquote { color: #00acac; display: block; font-style: italic; } pre { display: block; } a { color: #3c66e2; font-style: underline; } body { color: #ddd; background-color: #20272b; margin: 1px; font-size: 1em; padding: 0.2em; } .danger { color: #e63525; } .important, .attention { color: #9774cb; } .caution, .warning { color: #fb8764; } .note { color: #c26b2b; }]]>",
+        "highlightForeground" : "#f5f5f5",
+        "tagsOptions" : "underline",
+        "bracketContentsOptions" : "underline",
+        "bracketContentsForeground" : "#eee",
+        "bracketsOptions" : "underline",
+        "bracketsForeground" : "#eee",
+        "gutterForeground" : "#ddd"
       }
     },
     {
-      "scope" : "comment",
+      "scope" : "comment, punctuation.definition.comment, string.comment",
       "settings" : {
         "foreground" : "#969896"
       },
       "name" : "Comment"
     },
     {
-      "scope" : "constant, variable.other.constant",
+      "scope" : "constant, entity.name.constant, variable.other.constant, variable.language",
       "settings" : {
         "foreground" : "#0099cd"
       },
@@ -115,6 +131,14 @@
       }
     },
     {
+      "scope" : "invalid.broken",
+      "settings" : {
+        "fontStyle" : "bold italic underline",
+        "foreground" : "#e63525"
+      },
+      "name" : "Invalid - Broken"
+    },
+    {
       "scope" : "invalid.deprecated",
       "settings" : {
         "fontStyle" : "bold italic underline",
@@ -130,6 +154,20 @@
         "background" : "#e63525"
       },
       "name" : "Invalid – Illegal"
+    },
+    {
+      "scope" : "invalid.unimplemented",
+      "settings" : {
+        "fontStyle" : "bold italic underline",
+        "foreground" : "#e63525"
+      },
+      "name" : "Invalid - Unimplemented"
+    },
+    {
+      "scope" : "message.error",
+      "settings" : {
+        "foreground" : "#e63525"
+      }
     },
     {
       "scope" : "string source",
@@ -148,7 +186,7 @@
       "name" : "String variable"
     },
     {
-      "scope" : "string.regexp",
+      "scope" : "source.regexp, string.regexp",
       "settings" : {
         "fontStyle" : "",
         "foreground" : "#3c66e2"
@@ -239,7 +277,7 @@
       "name" : "Markup.raw"
     },
     {
-      "scope" : "markup.deleted, meta.diff.header.from-file",
+      "scope" : "markup.deleted, meta.diff.header.from-file, punctuation.definition.deleted",
       "settings" : {
         "background": "#ffecec",
         "foreground" : "#bd2c00"
@@ -247,12 +285,26 @@
       "name" : "Markup.deleted"
     },
     {
-      "scope": "markup.inserted, meta.diff.header.to-file",
+      "scope": "markup.inserted, meta.diff.header.to-file, punctuation.definition.inserted",
       "settings" : {
         "background": "#eaffea",
         "foreground" : "#55a532"
       },
       "name" : "Markup.inserted"
+    },
+    {
+      "scope" : "markup.changed, punctuation.definition.changed",
+      "settings" : {
+        "background" : "#ffe3b4",
+        "foreground" : "#ef9700"
+      }
+    },
+    {
+      "scope" : "markup.ignored, markup.untracked",
+      "settings" : {
+        "foreground" : "#d8d8d8",
+        "background" : "#808080"
+      }
     },
     {
       "scope": "meta.diff.range",
@@ -280,6 +332,43 @@
       "scope": "meta.output",
       "settings" : {
         "foreground": "#264ec5"
+      }
+    },
+    {
+      "scope" : "brackethighlighter.tag, brackethighlighter.curly, brackethighlighter.round, brackethighlighter.square, brackethighlighter.angle, brackethighlighter.quote",
+      "settings" : {
+        "foreground" : "#e1e1e1"
+      }
+    },
+    {
+      "scope" : "brackethighlighter.unmatched",
+      "settings" : {
+        "foreground" : "#e63525"
+      }
+    },
+    {
+      "scope" : "sublimelinter.mark.error",
+      "settings" : {
+        "foreground" : "#e63525"
+      }
+    },
+    {
+      "scope" : "sublimelinter.mark.warning",
+      "settings" : {
+        "foreground" : "#fb8764"
+      }
+    },
+    {
+      "scope" : "sublimelinter.gutter-mark",
+      "settings" : {
+        "foreground" : "#6e7880"
+      }
+    },
+    {
+      "scope" : "constant.other.reference.link, string.other.link",
+      "settings" : {
+        "foreground" : "#3c66e2",
+        "fontStyle" : "underline"
       }
     }
   ],

--- a/lib/themes/light.json
+++ b/lib/themes/light.json
@@ -1,73 +1,89 @@
 {
-  "author" : "GitHub",
-  "settings" : [
+  "author": "GitHub",
+  "settings": [
     {
-      "settings" : {
-        "selection" : "#c8c8fa",
-        "lineHighlight" : "#f5f5f5",
-        "background" : "#fff",
-        "foreground" : "#333",
-        "invisibles" : "#c0c0c0",
-        "caret" : "#000",
+      "settings": {
+        "selection": "#c8c8fa",
+        "lineHighlight": "#f5f5f5",
+        "background": "#fff",
+        "foreground": "#333",
+        "invisibles": "#c0c0c0",
+        "caret": "#000",
         "diffDeleted": "#ffecec",
         "diffAdded": "#eaffea",
-        "markdown": "#f7f7f7"
+        "markdown": "#f7f7f7",
+        "inactiveSelection": "#f5f5f5",
+        "selectionBorder": "#f5f5f5",
+        "findHighlight": "#ed6a43",
+        "findHighlightForeground": "#fff",
+        "guide": "#c0c0c0",
+        "activeGuide": "#333",
+        "stackGuide": "#acacac",
+        "highlight": "#464a4d",
+        "popupCss": "<![CDATA[html { background-color: #e0e0e0; } h1, h2, h3, h4, h5, h6 { color: #1d3e81; margin-top: 0.2em; margin-bottom: 0.2em; } h1 { font-size: 1.5em; } h2 { font-size: 1.4em; } h3 { font-size: 1.3em; } h4 { font-size: 1.2em; } h5 { font-size: 1.1em; } h6 { font-size: 1em; } blockquote { color: #008080; display: block; font-style: italic; } pre { display: block; } a { color: #183691; font-style: underline; } body { color: #333; background-color: #fff; margin: 1px; font-size: 1em; padding: 0.2em; } .danger { color: #b52a1d; } .important, .attention { color: #795da3; } .caution, .warning { color: #ed6a43; } .note { color: #693a17; }]]>",
+        "highlightForeground": "#464a4d",
+        "tagsOptions": "underline",
+        "bracketContentsOptions": "underline",
+        "bracketContentsForeground": "#181818",
+        "bracketsOptions": "underline",
+        "bracketsForeground": "#181818",
+        "gutterForeground": "#333"
       }
     },
     {
-      "scope" : "comment",
-      "settings" : {
-        "foreground" : "#969896"
+      "scope": "comment, punctuation.definition.comment, string.comment",
+      "settings": {
+        "foreground": "#969896"
       },
-      "name" : "Comment"
+      "name": "Comment"
     },
     {
-      "scope" : "constant, variable.other.constant",
-      "settings" : {
-        "foreground" : "#0086b3"
+      "scope": "constant, entity.name.constant, variable.other.constant, variable.language",
+      "settings": {
+        "foreground": "#0086b3"
       },
-      "name" : "Constant"
+      "name": "Constant"
     },
     {
-      "scope" : "keyword.operator.symbole, keyword.other.mark",
+      "scope": "keyword.operator.symbole, keyword.other.mark",
       "name": "Clojure workaround; don't highlight these separately from their enclosing scope",
       "settings": {}
     },
     {
-      "scope" : "entity, entity.name",
-      "settings" : {
-        "fontStyle" : "",
-        "foreground" : "#795da3"
+      "scope": "entity, entity.name",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#795da3"
       },
-      "name" : "Entity"
+      "name": "Entity"
     },
     {
       "scope": "variable.parameter.function",
-      "settings" : {
-        "foreground" : "#333"
+      "settings": {
+        "foreground": "#333"
       }
     },
     {
       "scope": "entity.name.tag",
-      "settings" : {
-        "fontStyle" : "",
-        "foreground" : "#63a35c"
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#63a35c"
       }
     },
     {
-      "scope" : "keyword",
-      "settings" : {
-        "fontStyle" : "",
-        "foreground" : "#a71d5d"
+      "scope": "keyword",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#a71d5d"
       },
-      "name" : "Keyword"
+      "name": "Keyword"
     },
     {
-      "scope" : "storage, storage.type",
-      "settings" : {
-        "foreground" : "#a71d5d"
+      "scope": "storage, storage.type",
+      "settings": {
+        "foreground": "#a71d5d"
       },
-      "name" : "Storage"
+      "name": "Storage"
     },
     {
       "scope": "storage.modifier.package, storage.modifier.import, storage.type.java",
@@ -76,12 +92,12 @@
       }
     },
     {
-      "scope" : "string, punctuation.definition.string, string punctuation.section.embedded source",
-      "settings" : {
-        "fontStyle" : "",
-        "foreground" : "#183691"
+      "scope": "string, punctuation.definition.string, string punctuation.section.embedded source",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#183691"
       },
-      "name" : "String"
+      "name": "String"
     },
     {
       "name": "Ada workaround; don't highlight imports as strings",
@@ -89,27 +105,27 @@
       "settings": {}
     },
     {
-      "scope" : "support",
-      "settings" : {
-        "fontStyle" : "",
-        "foreground" : "#0086b3"
+      "scope": "support",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#0086b3"
       },
-      "name" : "Support"
+      "name": "Support"
     },
     {
       "scope": "meta.property-name",
-      "settings" : {
-        "fontStyle" : "",
-        "foreground" : "#0086b3"
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#0086b3"
       }
     },
     {
-      "scope" : "variable",
-      "settings" : {
-        "fontStyle" : "",
-        "foreground" : "#ed6a43"
+      "scope": "variable",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#ed6a43"
       },
-      "name" : "Variable"
+      "name": "Variable"
     },
     {
       "scope": "variable.other",
@@ -118,165 +134,201 @@
       }
     },
     {
-      "scope" : "invalid.deprecated",
-      "settings" : {
-        "fontStyle" : "bold italic underline",
-        "foreground" : "#b52a1d"
+      "scope": "invalid.broken",
+      "settings": {
+        "fontStyle": "bold italic underline",
+        "foreground": "#b52a1d"
       },
-      "name" : "Invalid – Deprecated"
+      "name": "Invalid - Broken"
     },
     {
-      "scope" : "invalid.illegal",
-      "settings" : {
-        "fontStyle" : "italic underline",
-        "background" : "#b52a1d",
-        "foreground" : "#f8f8f8"
+      "scope": "invalid.deprecated",
+      "settings": {
+        "fontStyle": "bold italic underline",
+        "foreground": "#b52a1d"
       },
-      "name" : "Invalid – Illegal"
+      "name": "Invalid – Deprecated"
     },
     {
-      "scope" : "string source",
-      "settings" : {
-        "fontStyle" : "",
-        "foreground" : "#333"
+      "scope": "invalid.illegal",
+      "settings": {
+        "fontStyle": "italic underline",
+        "background": "#b52a1d",
+        "foreground": "#f8f8f8"
       },
-      "name" : "String embedded-source"
+      "name": "Invalid – Illegal"
     },
     {
-      "scope" : "string variable",
-      "settings" : {
-        "fontStyle" : "",
-        "foreground" : "#0086b3"
+      "scope": "invalid.unimplemented",
+      "settings": {
+        "fontStyle": "bold italic underline",
+        "foreground": "#b52a1d"
       },
-      "name" : "String variable"
+      "name": "Invalid - Unimplemented"
     },
     {
-      "scope" : "string.regexp",
-      "settings" : {
-        "fontStyle" : "",
-        "foreground" : "#183691"
-      },
-      "name" : "String.regexp"
+      "scope": "message.error",
+      "settings": {
+        "foreground": "#b52a1d"
+      }
     },
     {
-      "scope" : "string.regexp.character-class, string.regexp constant.character.escape, string.regexp source.ruby.embedded, string.regexp string.regexp.arbitrary-repitition",
-      "settings" : {
-        "foreground" : "#183691"
+      "scope": "string source",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#333"
       },
-      "name" : "String.regexp.«special»"
+      "name": "String embedded-source"
     },
     {
-      "scope" : "string.regexp constant.character.escape",
-      "settings" : {
-        "fontStyle" : "bold",
-        "foreground" : "#63a35c"
+      "scope": "string variable",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#0086b3"
       },
-      "name" : "String.regexp constant.character.escape"
+      "name": "String variable"
     },
     {
-      "scope" : "support.constant",
-      "settings" : {
-        "fontStyle" : "",
-        "foreground" : "#0086b3"
+      "scope": "source.regexp, string.regexp",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#183691"
       },
-      "name" : "Support.constant"
+      "name": "String.regexp"
     },
     {
-      "scope" : "support.variable",
-      "settings" : {
-        "foreground" : "#0086b3"
+      "scope": "string.regexp.character-class, string.regexp constant.character.escape, string.regexp source.ruby.embedded, string.regexp string.regexp.arbitrary-repitition",
+      "settings": {
+        "foreground": "#183691"
       },
-      "name" : "Support.variable"
+      "name": "String.regexp.«special»"
+    },
+    {
+      "scope": "string.regexp constant.character.escape",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#63a35c"
+      },
+      "name": "String.regexp constant.character.escape"
+    },
+    {
+      "scope": "support.constant",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#0086b3"
+      },
+      "name": "Support.constant"
+    },
+    {
+      "scope": "support.variable",
+      "settings": {
+        "foreground": "#0086b3"
+      },
+      "name": "Support.variable"
     },
     {
       "scope": "meta.module-reference",
-      "settings" : {
-        "foreground" : "#0086b3"
+      "settings": {
+        "foreground": "#0086b3"
       },
       "name": "meta module-reference"
     },
     {
-      "scope" : "markup.list",
-      "settings" : {
-        "foreground" : "#693a17"
+      "scope": "markup.list",
+      "settings": {
+        "foreground": "#693a17"
       },
-      "name" : "Markup.list"
+      "name": "Markup.list"
     },
     {
-      "scope" : "markup.heading, markup.heading entity.name",
-      "settings" : {
-        "fontStyle" : "bold",
-        "foreground" : "#1d3e81"
+      "scope": "markup.heading, markup.heading entity.name",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#1d3e81"
       },
-      "name" : "Markup.heading"
+      "name": "Markup.heading"
     },
     {
-      "scope" : "markup.quote",
-      "settings" : {
-        "foreground" : "#008080"
+      "scope": "markup.quote",
+      "settings": {
+        "foreground": "#008080"
       },
-      "name" : "Markup.quote"
+      "name": "Markup.quote"
     },
     {
-      "scope" : "markup.italic",
-      "settings" : {
-        "fontStyle" : "italic",
-        "foreground" : "#333"
+      "scope": "markup.italic",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#333"
       },
-      "name" : "Markup.italic"
+      "name": "Markup.italic"
     },
     {
-      "scope" : "markup.bold",
-      "settings" : {
-        "fontStyle" : "bold",
-        "foreground" : "#333"
+      "scope": "markup.bold",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#333"
       },
-      "name" : "Markup.bold"
+      "name": "Markup.bold"
     },
     {
-      "scope" : "markup.raw",
-      "settings" : {
-        "fontStyle" : "",
-        "foreground" : "#0086b3"
+      "scope": "markup.raw",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#0086b3"
       },
-      "name" : "Markup.raw"
+      "name": "Markup.raw"
     },
     {
-      "scope" : "markup.deleted, meta.diff.header.from-file",
-      "settings" : {
+      "scope": "markup.deleted, meta.diff.header.from-file, punctuation.definition.deleted",
+      "settings": {
         "background": "#ffecec",
-        "foreground" : "#bd2c00"
+        "foreground": "#bd2c00"
       },
-      "name" : "Markup.deleted"
+      "name": "Markup.deleted"
     },
     {
-      "scope": "markup.inserted, meta.diff.header.to-file",
-      "settings" : {
+      "scope": "markup.inserted, meta.diff.header.to-file, punctuation.definition.inserted",
+      "settings": {
         "background": "#eaffea",
-        "foreground" : "#55a532"
+        "foreground": "#55a532"
       },
-      "name" : "Markup.inserted"
+      "name": "Markup.inserted"
+    },
+    {
+      "scope": "markup.changed, punctuation.definition.changed",
+      "settings": {
+        "background": "#ffe3b4",
+        "foreground": "#ef9700"
+      }
+    },
+    {
+      "scope": "markup.ignored, markup.untracked",
+      "settings": {
+        "foreground": "#d8d8d8",
+        "background": "#808080"
+      }
     },
     {
       "scope": "meta.diff.range",
-      "settings" : {
-        "foreground" : "#795da3",
+      "settings": {
+        "foreground": "#795da3",
         "fontStyle": "bold"
       }
     },
     {
       "scope": "meta.diff.header",
-      "settings" : {
-        "foreground" : "#0086b3"
+      "settings": {
+        "foreground": "#0086b3"
       }
     },
     {
-      "scope" : "meta.separator",
-      "settings" : {
-        "fontStyle" : "bold",
-        "foreground" : "#1d3e81"
+      "scope": "meta.separator",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#1d3e81"
       },
-      "name" : "Meta.separator"
+      "name": "Meta.separator"
     },
     {
       "name": "Output",
@@ -284,11 +336,48 @@
       "settings": {
         "foreground": "#1d3e81"
       }
+    },
+    {
+      "scope" : "brackethighlighter.tag, brackethighlighter.curly, brackethighlighter.round, brackethighlighter.square, brackethighlighter.angle, brackethighlighter.quote",
+      "settings" : {
+        "foreground" : "#595e62"
+      }
+    },
+    {
+      "scope" : "brackethighlighter.unmatched",
+      "settings" : {
+        "foreground" : "#b52a1d"
+      }
+    },
+    {
+      "scope" : "sublimelinter.mark.error",
+      "settings" : {
+        "foreground" : "#b52a1d"
+      }
+    },
+    {
+      "scope" : "sublimelinter.mark.warning",
+      "settings" : {
+        "foreground" : "#ed6a43"
+      }
+    },
+    {
+      "scope" : "sublimelinter.gutter-mark",
+      "settings" : {
+        "foreground" : "#c0c0c0"
+      }
+    },
+    {
+      "scope" : "constant.other.reference.link, string.other.link",
+      "settings" : {
+        "foreground" : "#183691",
+        "fontStyle" : "underline"
+      }
     }
   ],
-  "comment" : "GitHub Light syntax theme",
-  "name" : "GitHub Light",
-  "semanticClass" : "theme.light.github",
+  "comment": "GitHub Light syntax theme",
+  "name": "GitHub Light",
+  "semanticClass": "theme.light.github",
   "filename": "github-light",
   "uuid": "A1C4DFA0-7031-11E4-9803-0800200C9A66"
 }

--- a/test/accessibility.js
+++ b/test/accessibility.js
@@ -3,8 +3,8 @@ import colorable from "colorable"
 import themes from "../lib/themes"
 
 
-var foregrounds = ["foreground", "caret", "invisibles"]
-
+var foregrounds = ["foreground", "caret", "invisibles", "findHighlightForeground", "highlightForeground", "bracketContentsForeground", "bracketsForeground", "gutterForeground"]
+var ignore = ["selectionBorder", "guide", "activeGuide", "stackGuide"]
 
 function colorTest(background, foreground, message) {
   // Calculate contrast
@@ -35,6 +35,10 @@ themes.forEach(theme => {
     return !setting.scope
   }).pop()
 
+  ignore.forEach(i =>  {
+    delete bgColors.settings[i]
+  })
+
   var themeForegrounds = foregrounds.map(foreground => {
     return {
       "scope": foreground,
@@ -56,16 +60,19 @@ themes.forEach(theme => {
       if (setting.settings.background) {
         // check against it's own background color
         colorTest(setting.settings.background, foreground, theme.name + ": " + setting.scope + " (" + foreground + ") on " + setting.settings.background + " background")
-      } else {
-        // For each background color
-        Object.keys(bgColors.settings).forEach( bg => {
-          if(foregrounds.indexOf(bg) == -1) {
-            // Get the background color
-            var background = bgColors.settings[bg]
+        foreground = setting.settings.background
+      }
+
+      // For each background color
+      Object.keys(bgColors.settings).forEach( bg => {
+        if(foregrounds.indexOf(bg) == -1) {
+          // Get the background color
+          var background = bgColors.settings[bg]
+          if (background.indexOf("#") == 0) {
             colorTest(background, foreground, theme.name + ": " + setting.scope + " (" + foreground + ") on " + bg + " (" + background + ") background")
           }
-        })
-      }
+        }
+      })
     }
   })
 })


### PR DESCRIPTION
This pulls in changes made by @buildersbrewery in https://github.com/primer/github-syntax-theme-generator/pull/1

I had to pull them in this way because I separated the theme files in #2 

I also updated the accessibility tests to account for the new backgrounds. And made the tests compare scopes with their own backgrounds against global backgrounds.

@buildersbrewery can you 👀 look over this pull and make sure it captures your changes?

closes #1 