### PR TITLE
Add carriage.return scope; generate content style

### DIFF
--- a/lib/adapters/css.js
+++ b/lib/adapters/css.js
@@ -29,6 +29,10 @@ module.exports = (theme) => {
       attributes["background-color"] = a.background
     }
 
+    if (a.content) {
+      attributes["content"] = a.content
+    }
+
     return attributes
   }
 
@@ -87,7 +91,7 @@ module.exports = (theme) => {
     })
   })
 
-  rules = _.map(selectorsByStyle, (selectors, style) => {
+  rules = _.flatMap(selectorsByStyle, (selectors, style) => {
     style = JSON.parse(style)
 
     var scopeSelectorsByCss = _.groupBy(selectors, selector => {
@@ -96,10 +100,27 @@ module.exports = (theme) => {
       return classes.map( c => { return "." + c }).join(" ")
     })
 
-    return {
+    var content
+    if (style.content) {
+      content = style.content;
+      delete style.content;
+    }
+
+    const styles = [{
       "style": style,
       "selectors": _.map(scopeSelectorsByCss, (scopes, css) => { return { "css": css, "scopes": scopes }})
+    }]
+
+    if (content) {
+      styles.push({
+        "style": {
+          "content": "\"" + content.replace(/"/g, "\\22 ") + "\"",
+        },
+        "selectors": _.map(scopeSelectorsByCss, (scopes, css) => { return { "css": css + "::before", "scopes": scopes }})
+      })
     }
+
+    return styles
   })
 
   var output = header(theme)

--- a/lib/themes/dark.json
+++ b/lib/themes/dark.json
@@ -156,6 +156,16 @@
       "name" : "Invalid – Illegal"
     },
     {
+      "scope" : "carriage.return",
+      "settings" : {
+        "fontStyle" : "italic underline",
+        "foreground" : "#f8f8f8",
+        "background" : "#e63525",
+        "content": "^M"
+      },
+      "name" : "Carriage Return"
+    },
+    {
       "scope" : "invalid.unimplemented",
       "settings" : {
         "fontStyle" : "bold italic underline",

--- a/lib/themes/light.json
+++ b/lib/themes/light.json
@@ -159,6 +159,16 @@
       "name": "Invalid – Illegal"
     },
     {
+      "scope": "carriage.return",
+      "settings": {
+        "fontStyle": "italic underline",
+        "background": "#b52a1d",
+        "foreground": "#f8f8f8",
+        "content": "^M"
+      },
+      "name": "Carriage Return"
+    },
+    {
       "scope": "invalid.unimplemented",
       "settings": {
         "fontStyle": "bold italic underline",


### PR DESCRIPTION
This PR adds support for customizing how we render CR characters on the syntax themes.

cc @jonrohan @aroben