### PR TITLE
Creating a CodeMirror adapter for the GitHub syntax theme

### DIFF
--- a/lib/adapters/atom.js
+++ b/lib/adapters/atom.js
@@ -1,5 +1,6 @@
 const mkdirp = require("mkdirp")
 const fs = require("fs")
+const utils = require("../utils")
 
 module.exports = (theme) => {
   mkdirp.sync(`build/atom/${theme.filename}`)
@@ -7,35 +8,6 @@ module.exports = (theme) => {
   let languages = ""
   let syntaxVariables = fs.readFileSync("./lib/templates/atom/syntax-variables.less").toString()
   const editor = fs.readFileSync("./lib/templates/atom/editor.less")
-  const declarationMap = {
-    "foreground": "color",
-    "background": "background-color"
-  }
-
-  function cssDeclarations(settings) {
-    let declarations = ""
-    Object.keys(settings).forEach((key) => {
-      if (key === "fontStyle") {
-        const value = settings[key]
-        if (value.trim() === "") {
-          declarations += "\n  font-weight: normal;\n  font-style: normal;\n  text-decoration: none;"
-        } else {
-          value.split(" ").forEach((val) => {
-            if (val === "bold") {
-              declarations += "\n  font-weight: bold;"
-            } else if (val === "italic") {
-              declarations += "\n  font-style: italic;"
-            } else if (val === "underline") {
-              declarations += "\n  text-decoration: underline;"
-            }
-          })
-        }
-      } else {
-        declarations += `\n  ${declarationMap[key]}: ${settings[key]};`
-      }
-    })
-    return declarations
-  }
 
   theme.settings.forEach((setting) => {
     const settings = setting.settings
@@ -47,7 +19,7 @@ module.exports = (theme) => {
         syntaxVariables = syntaxVariables.replace(new RegExp("\\${" + key + "}", "g"), settings[key])
       })
     } else {
-      languages += `\n.${scope.split(" ").join(" .").split(", ").join(",\n")} {${cssDeclarations(settings)}\n}\n`
+      languages += `\n.${scope.split(" ").join(" .").split(", ").join(",\n")} {${utils.declarations(settings)}\n}\n`
     }
   })
 

--- a/lib/adapters/codemirror.js
+++ b/lib/adapters/codemirror.js
@@ -1,0 +1,37 @@
+const mkdirp = require("mkdirp")
+const fs = require("fs")
+const sass = require("node-sass")
+const utils = require("../utils")
+
+module.exports = (theme) => {
+  mkdirp.sync(`build/codemirror`)
+
+  let template = fs.readFileSync("./lib/templates/codemirror.scss").toString()
+  let output = utils.header(theme)
+
+  template = template.replace(new RegExp("\\${theme}", "g"), theme.filename)
+
+  theme.settings.forEach((setting) => {
+    const settings = setting.settings
+    const scope = setting.scope
+
+    // Editor settings
+    if (!scope) {
+      Object.keys(settings).forEach((key) => {
+        template = template.replace(new RegExp("\\${" + key + "}", "g"), settings[key])
+      })
+      output += template
+    } else {
+      const singleScope = scope.split(", ")[0]
+      if (singleScope && !singleScope.match(/[\.\s\-]/)) {
+        output += `\n.cm-s-${theme.filename} .cm-${singleScope} { ${utils.declarations(settings)} }`
+      }
+    }
+  })
+
+  const result = sass.renderSync({
+    data: output,
+    includePaths: ["./node_modules"]
+  })
+  fs.writeFileSync(`./build/codemirror/codemirror-${theme.filename}-theme.css`, result.css)
+}

--- a/lib/adapters/index.js
+++ b/lib/adapters/index.js
@@ -1,9 +1,11 @@
 const css = require("./css")
 const tmtheme = require("./tmtheme")
 const atom = require("./atom")
+const codemirror = require("./codemirror")
 
 module.exports = {
   "css": css,
   "tmtheme": tmtheme,
+  "codemirror": codemirror,
   "atom": atom
 }

--- a/lib/templates/codemirror.scss
+++ b/lib/templates/codemirror.scss
@@ -1,0 +1,57 @@
+@import "primer-support/index.scss";
+
+.cm-s-${theme} {
+
+  &.CodeMirror {
+    background: ${background};
+    color: ${foreground};
+  }
+
+  .CodeMirror-gutters {
+    background: ${background};
+    border-right-width: 0;
+  }
+
+  .CodeMirror-guttermarker {
+    color: white;
+  }
+
+  .CodeMirror-guttermarker-subtle {
+    color: #d0d0d0;
+  }
+
+  .CodeMirror-linenumber {
+    color: ${invisibles};
+    padding: 0 $spacer-3 0 $spacer-3;
+  }
+
+  .CodeMirror-cursor {
+    border-left: 1px solid ${foreground};
+  }
+
+  div.CodeMirror-selected,
+  .CodeMirror-line::selection,
+  .CodeMirror-line > span::selection,
+  .CodeMirror-line > span > span::selection,
+  .CodeMirror-line::-moz-selection,
+  .CodeMirror-line > span::-moz-selection,
+  .CodeMirror-line > span > span::-moz-selection {
+    background: ${selection};
+  }
+
+  .CodeMirror-activeline-background {
+    background: ${lineHighlight};
+  }
+
+  .CodeMirror-matchingbracket {
+    text-decoration: underline;
+    color: ${foreground} !important;
+  }
+
+  .CodeMirror-lines {
+    font-family: $mono-font;
+    font-size: $h6-size;
+    background: ${background};
+    line-height: 20px;
+  }
+}

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -7,3 +7,34 @@ module.exports.header = (theme) => {
  * Licensed under MIT (https://github.com/primer/github-syntax-theme-generator/blob/master/LICENSE)
  */\n\n`
 }
+
+module.exports.property = (key) => {
+  const map = {
+    "foreground": "color",
+    "background": "background-color",
+    "bold": "font-weight",
+    "italic": "font-style",
+    "underline": "text-decoration"
+  }
+
+  return map[key]
+}
+
+module.exports.declarations = (settings) => {
+  let declarations = ""
+  Object.keys(settings).forEach((key) => {
+    if (key === "fontStyle") {
+      const value = settings[key]
+      if (value.trim() === "") {
+        declarations += "\n  font-weight: normal;\n  font-style: normal;\n  text-decoration: none;"
+      } else {
+        value.split(" ").forEach((val) => {
+          declarations += `\n  ${module.exports.property(val)}: ${val};`
+        })
+      }
+    } else {
+      declarations += `\n  ${module.exports.property(key)}: ${settings[key]};`
+    }
+  })
+  return declarations
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepublish": "npm run build",
     "ava": "ava --verbose --fail-fast \"test/**/*.js\"",
     "lint": "eslint **/*.js",
-    "test": "npm run lint && npm run ava"
+    "test": "npm run lint && npm run build && npm run ava"
   },
   "devDependencies": {
     "ace": "git+https://github.com/ajaxorg/ace.git",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "eslint-plugin-github": "^0.6.1",
     "lodash": "^4.16.6",
     "mkdirp": "^0.5.1",
-    "plist": "^2.0.1"
+    "node-sass": "^3.13.0",
+    "plist": "^2.0.1",
+    "primer-support": "^1.1.0"
   },
   "keywords": [
     "syntax",


### PR DESCRIPTION
This pull creates a CodeMirror adapter to output the GitHub syntax theme. Once this is merged and in, I'll create a `codemirror-github-light` and `codemirror-github-dark` theme repositories so we can use them.

**How it looks**

![image](https://cloud.githubusercontent.com/assets/54012/21070578/060a328e-be56-11e6-865b-4eed33169091.png)

**Example of the output**

```css
/*!
 * GitHub Light v0.3.2
 * Copyright (c) 2012 - 2016 GitHub, Inc.
 * Licensed under MIT (https://github.com/primer/github-syntax-theme-generator/blob/master/LICENSE)
 */
.cm-s-github-light.CodeMirror {
  background: #fff;
  color: #333; }

.cm-s-github-light .CodeMirror-gutters {
  background: #fff;
  border-right-width: 0; }

.cm-s-github-light .CodeMirror-guttermarker {
  color: white; }

.cm-s-github-light .CodeMirror-guttermarker-subtle {
  color: #d0d0d0; }

.cm-s-github-light .CodeMirror-linenumber {
  color: #c0c0c0;
  padding: 0 16px 0 16px; }

.cm-s-github-light .CodeMirror-cursor {
  border-left: 1px solid #333; }

.cm-s-github-light div.CodeMirror-selected,
.cm-s-github-light .CodeMirror-line::selection,
.cm-s-github-light .CodeMirror-line > span::selection,
.cm-s-github-light .CodeMirror-line > span > span::selection,
.cm-s-github-light .CodeMirror-line::-moz-selection,
.cm-s-github-light .CodeMirror-line > span::-moz-selection,
.cm-s-github-light .CodeMirror-line > span > span::-moz-selection {
  background: #c8c8fa; }

.cm-s-github-light .CodeMirror-activeline-background {
  background: #f5f5f5; }

.cm-s-github-light .CodeMirror-matchingbracket {
  text-decoration: underline;
  color: #333 !important; }

.cm-s-github-light .CodeMirror-lines {
  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
  font-size: 12px;
  background: #fff;
  line-height: 18px; }

.cm-s-github-light .cm-comment {
  color: #969896; }

.cm-s-github-light .cm-constant {
  color: #0086b3; }

.cm-s-github-light .cm-entity {
  font-weight: normal;
  font-style: normal;
  text-decoration: none;
  color: #795da3; }

.cm-s-github-light .cm-keyword {
  font-weight: normal;
  font-style: normal;
  text-decoration: none;
  color: #a71d5d; }

.cm-s-github-light .cm-storage {
  color: #a71d5d; }

.cm-s-github-light .cm-string {
  font-weight: normal;
  font-style: normal;
  text-decoration: none;
  color: #183691; }

.cm-s-github-light .cm-support {
  font-weight: normal;
  font-style: normal;
  text-decoration: none;
  color: #0086b3; }

.cm-s-github-light .cm-variable {
  font-weight: normal;
  font-style: normal;
  text-decoration: none;
  color: #ed6a43; }
```

@josh @tberman