### PR TITLE
Fix the Atom adapter for the Shadow DOM removal

### DIFF
--- a/lib/adapters/atom.js
+++ b/lib/adapters/atom.js
@@ -2,6 +2,18 @@ const mkdirp = require("mkdirp")
 const fs = require("fs")
 const utils = require("../utils")
 
+function updateScope (scopeText) {
+  return scopeText.split(" ")
+                  .map((scope) => {
+                    return scope.split(".")
+                                .map((scopePart) => { return `syntax--${scopePart}` })
+                                .join(".")
+                  })
+                  .join(" .")
+                  .split(", ")
+                  .join(",\n")
+}
+
 module.exports = (theme) => {
   mkdirp.sync(`build/atom/${theme.filename}`)
 
@@ -19,7 +31,7 @@ module.exports = (theme) => {
         syntaxVariables = syntaxVariables.replace(new RegExp("\\${" + key + "}", "g"), settings[key])
       })
     } else {
-      languages += `\n.${scope.split(" ").join(" .").split(", ").join(",\n")} {${utils.declarations(settings)}\n}\n`
+      languages += `\n.${updateScope(scope)} {${utils.declarations(settings)}\n}\n`
     }
   })
 

--- a/lib/templates/atom/editor.less
+++ b/lib/templates/atom/editor.less
@@ -1,4 +1,4 @@
-atom-text-editor, :host {
+atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
@@ -79,13 +79,11 @@ atom-text-editor, :host {
   }
 }
 
-atom-text-editor .search-results .marker .region,
-:host .search-results .marker .region {
+atom-text-editor .search-results .syntax--marker .region {
   background-color: transparent;
   border: 1px solid @syntax-result-marker-color;
 }
 
-atom-text-editor .search-results .marker.current-result .region,
-:host .search-results .marker.current-result .region {
+atom-text-editor .search-results .syntax--marker.current-result .region {
   border: 1px solid @syntax-result-marker-color-selected;
 }

--- a/test/utils/header.js
+++ b/test/utils/header.js
@@ -22,7 +22,7 @@ test("the current package version", t => {
 })
 
 test("correct year", t => {
-  t.regex(darkThemeHeader, /2016/)
+  t.regex(darkThemeHeader, /2017/)
 })
 
 test("package author", t => {


### PR DESCRIPTION
In v1.13 of Atom, [the Shadow DOM was removed](http://blog.atom.io/2016/11/14/removing-shadow-dom-boundary-from-text-editor-elements.html). This necessitates a few updates to syntax themes. This PR updates the Atom adapter code to comply with those changes. The new built version will not show any style deprecations.