### PR TITLE
Update light theme based on new GitHub color system

### DIFF
--- a/lib/themes/light.json
+++ b/lib/themes/light.json
@@ -4,45 +4,45 @@
     {
       "settings": {
         "selection": "#c8c8fa",
-        "lineHighlight": "#f5f5f5",
+        "lineHighlight": "#fafbfc",
         "background": "#fff",
-        "foreground": "#333",
-        "invisibles": "#c0c0c0",
-        "caret": "#000",
-        "diffRenamed": "#f2f9fc",
-        "diffModified": "#fff9ea",
-        "diffDeleted": "#ffecec",
-        "diffAdded": "#eaffea",
+        "foreground": "#24292e",
+        "invisibles": "#959da5",
+        "caret": "#24292e",
+        "diffRenamed": "#f1f8ff",
+        "diffModified": "#fffdef",
+        "diffDeleted": "#ffeef0",
+        "diffAdded": "#f0fff4",
         "markdown": "#f7f7f7",
-        "inactiveSelection": "#f5f5f5",
-        "selectionBorder": "#f5f5f5",
-        "findHighlight": "#ed6a43",
-        "findHighlightForeground": "#fff",
-        "guide": "#c0c0c0",
-        "activeGuide": "#333",
-        "stackGuide": "#acacac",
-        "highlight": "#464a4d",
-        "popupCss": "<![CDATA[html { background-color: #e0e0e0; } h1, h2, h3, h4, h5, h6 { color: #1d3e81; margin-top: 0.2em; margin-bottom: 0.2em; } h1 { font-size: 1.5em; } h2 { font-size: 1.4em; } h3 { font-size: 1.3em; } h4 { font-size: 1.2em; } h5 { font-size: 1.1em; } h6 { font-size: 1em; } blockquote { color: #008080; display: block; font-style: italic; } pre { display: block; } a { color: #183691; font-style: underline; } body { color: #333; background-color: #fff; margin: 1px; font-size: 1em; padding: 0.2em; } .danger { color: #b52a1d; } .important, .attention { color: #795da3; } .caution, .warning { color: #ed6a43; } .note { color: #693a17; }]]>",
-        "highlightForeground": "#464a4d",
+        "inactiveSelection": "#fafbfc",
+        "selectionBorder": "#fafbfc",
+        "findHighlight": "#e36209",
+        "findHighlightForeground": "#fff8f2",
+        "guide": "#959da5",
+        "activeGuide": "#24292e",
+        "stackGuide": "#959da5",
+        "highlight": "#444d56",
+        "popupCss": "<![CDATA[html { background-color: #e0e0e0; } h1, h2, h3, h4, h5, h6 { color: #005cc5; margin-top: 0.2em; margin-bottom: 0.2em; } h1 { font-size: 1.5em; } h2 { font-size: 1.4em; } h3 { font-size: 1.3em; } h4 { font-size: 1.2em; } h5 { font-size: 1.1em; } h6 { font-size: 1em; } blockquote { color: #22863a; display: block; font-style: italic; } pre { display: block; } a { color: #032f62; font-style: underline; } body { color: #24292e; background-color: #fff; margin: 1px; font-size: 1em; padding: 0.2em; } .danger { color: #b31d28; } .important, .attention { color: #6f42c1; } .caution, .warning { color: #e36209; } .note { color: #735c0f; }]]>",
+        "highlightForeground": "#444d56",
         "tagsOptions": "underline",
         "bracketContentsOptions": "underline",
-        "bracketContentsForeground": "#181818",
+        "bracketContentsForeground": "#24292e",
         "bracketsOptions": "underline",
-        "bracketsForeground": "#181818",
-        "gutterForeground": "#333"
+        "bracketsForeground": "#24292e",
+        "gutterForeground": "#24292e"
       }
     },
     {
       "scope": "comment, punctuation.definition.comment, string.comment",
       "settings": {
-        "foreground": "#969896"
+        "foreground": "#6a737d"
       },
       "name": "Comment"
     },
     {
       "scope": "constant, entity.name.constant, variable.other.constant, variable.language",
       "settings": {
-        "foreground": "#0086b3"
+        "foreground": "#005cc5"
       },
       "name": "Constant"
     },
@@ -55,49 +55,49 @@
       "scope": "entity, entity.name",
       "settings": {
         "fontStyle": "",
-        "foreground": "#795da3"
+        "foreground": "#6f42c1"
       },
       "name": "Entity"
     },
     {
       "scope": "variable.parameter.function",
       "settings": {
-        "foreground": "#333"
+        "foreground": "#24292e"
       }
     },
     {
       "scope": "entity.name.tag",
       "settings": {
         "fontStyle": "",
-        "foreground": "#63a35c"
+        "foreground": "#22863a"
       }
     },
     {
       "scope": "keyword",
       "settings": {
         "fontStyle": "",
-        "foreground": "#a71d5d"
+        "foreground": "#d73a49"
       },
       "name": "Keyword"
     },
     {
       "scope": "storage, storage.type",
       "settings": {
-        "foreground": "#a71d5d"
+        "foreground": "#d73a49"
       },
       "name": "Storage"
     },
     {
       "scope": "storage.modifier.package, storage.modifier.import, storage.type.java",
       "settings": {
-        "foreground": "#333"
+        "foreground": "#24292e"
       }
     },
     {
       "scope": "string, punctuation.definition.string, string punctuation.section.embedded source",
       "settings": {
         "fontStyle": "",
-        "foreground": "#183691"
+        "foreground": "#032f62"
       },
       "name": "String"
     },
@@ -110,7 +110,7 @@
       "scope": "support",
       "settings": {
         "fontStyle": "",
-        "foreground": "#0086b3"
+        "foreground": "#005cc5"
       },
       "name": "Support"
     },
@@ -118,28 +118,28 @@
       "scope": "meta.property-name",
       "settings": {
         "fontStyle": "",
-        "foreground": "#0086b3"
+        "foreground": "#005cc5"
       }
     },
     {
       "scope": "variable",
       "settings": {
         "fontStyle": "",
-        "foreground": "#ed6a43"
+        "foreground": "#e36209"
       },
       "name": "Variable"
     },
     {
       "scope": "variable.other",
       "settings": {
-        "foreground": "#333"
+        "foreground": "#24292e"
       }
     },
     {
       "scope": "invalid.broken",
       "settings": {
         "fontStyle": "bold italic underline",
-        "foreground": "#b52a1d"
+        "foreground": "#b31d28"
       },
       "name": "Invalid - Broken"
     },
@@ -147,7 +147,7 @@
       "scope": "invalid.deprecated",
       "settings": {
         "fontStyle": "bold italic underline",
-        "foreground": "#b52a1d"
+        "foreground": "#b31d28"
       },
       "name": "Invalid – Deprecated"
     },
@@ -155,8 +155,8 @@
       "scope": "invalid.illegal",
       "settings": {
         "fontStyle": "italic underline",
-        "background": "#b52a1d",
-        "foreground": "#f8f8f8"
+        "background": "#b31d28",
+        "foreground": "#fafbfc"
       },
       "name": "Invalid – Illegal"
     },
@@ -164,8 +164,8 @@
       "scope": "carriage-return",
       "settings": {
         "fontStyle": "italic underline",
-        "background": "#b52a1d",
-        "foreground": "#f8f8f8",
+        "background": "#d73a49",
+        "foreground": "#fafbfc",
         "content": "^M"
       },
       "name": "Carriage Return"
@@ -174,21 +174,21 @@
       "scope": "invalid.unimplemented",
       "settings": {
         "fontStyle": "bold italic underline",
-        "foreground": "#b52a1d"
+        "foreground": "#b31d28"
       },
       "name": "Invalid - Unimplemented"
     },
     {
       "scope": "message.error",
       "settings": {
-        "foreground": "#b52a1d"
+        "foreground": "#b31d28"
       }
     },
     {
       "scope": "string source",
       "settings": {
         "fontStyle": "",
-        "foreground": "#333"
+        "foreground": "#24292e"
       },
       "name": "String embedded-source"
     },
@@ -196,7 +196,7 @@
       "scope": "string variable",
       "settings": {
         "fontStyle": "",
-        "foreground": "#0086b3"
+        "foreground": "#005cc5"
       },
       "name": "String variable"
     },
@@ -204,14 +204,14 @@
       "scope": "source.regexp, string.regexp",
       "settings": {
         "fontStyle": "",
-        "foreground": "#183691"
+        "foreground": "#032f62"
       },
       "name": "String.regexp"
     },
     {
       "scope": "string.regexp.character-class, string.regexp constant.character.escape, string.regexp source.ruby.embedded, string.regexp string.regexp.arbitrary-repitition",
       "settings": {
-        "foreground": "#183691"
+        "foreground": "#032f62"
       },
       "name": "String.regexp.«special»"
     },
@@ -219,7 +219,7 @@
       "scope": "string.regexp constant.character.escape",
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#63a35c"
+        "foreground": "#22863a"
       },
       "name": "String.regexp constant.character.escape"
     },
@@ -227,28 +227,28 @@
       "scope": "support.constant",
       "settings": {
         "fontStyle": "",
-        "foreground": "#0086b3"
+        "foreground": "#005cc5"
       },
       "name": "Support.constant"
     },
     {
       "scope": "support.variable",
       "settings": {
-        "foreground": "#0086b3"
+        "foreground": "#005cc5"
       },
       "name": "Support.variable"
     },
     {
       "scope": "meta.module-reference",
       "settings": {
-        "foreground": "#0086b3"
+        "foreground": "#005cc5"
       },
       "name": "meta module-reference"
     },
     {
       "scope": "markup.list",
       "settings": {
-        "foreground": "#693a17"
+        "foreground": "#735c0f"
       },
       "name": "Markup.list"
     },
@@ -256,14 +256,14 @@
       "scope": "markup.heading, markup.heading entity.name",
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#1d3e81"
+        "foreground": "#005cc5"
       },
       "name": "Markup.heading"
     },
     {
       "scope": "markup.quote",
       "settings": {
-        "foreground": "#008080"
+        "foreground": "#22863a"
       },
       "name": "Markup.quote"
     },
@@ -271,7 +271,7 @@
       "scope": "markup.italic",
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#333"
+        "foreground": "#24292e"
       },
       "name": "Markup.italic"
     },
@@ -279,7 +279,7 @@
       "scope": "markup.bold",
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#333"
+        "foreground": "#24292e"
       },
       "name": "Markup.bold"
     },
@@ -287,58 +287,58 @@
       "scope": "markup.raw",
       "settings": {
         "fontStyle": "",
-        "foreground": "#0086b3"
+        "foreground": "#005cc5"
       },
       "name": "Markup.raw"
     },
     {
       "scope": "markup.deleted, meta.diff.header.from-file, punctuation.definition.deleted",
       "settings": {
-        "background": "#ffecec",
-        "foreground": "#bd2c00"
+        "background": "#ffeef0",
+        "foreground": "#b31d28"
       },
       "name": "Markup.deleted"
     },
     {
       "scope": "markup.inserted, meta.diff.header.to-file, punctuation.definition.inserted",
       "settings": {
-        "background": "#eaffea",
-        "foreground": "#55a532"
+        "background": "#f0fff4",
+        "foreground": "#22863a"
       },
       "name": "Markup.inserted"
     },
     {
       "scope": "markup.changed, punctuation.definition.changed",
       "settings": {
-        "background": "#ffe3b4",
-        "foreground": "#ef9700"
+        "background": "#ffebda",
+        "foreground": "#e36209"
       }
     },
     {
       "scope": "markup.ignored, markup.untracked",
       "settings": {
-        "foreground": "#d8d8d8",
-        "background": "#808080"
+        "foreground": "#f6f8fa",
+        "background": "#005cc5"
       }
     },
     {
       "scope": "meta.diff.range",
       "settings": {
-        "foreground": "#795da3",
+        "foreground": "#6f42c1",
         "fontStyle": "bold"
       }
     },
     {
       "scope": "meta.diff.header",
       "settings": {
-        "foreground": "#0086b3"
+        "foreground": "#005cc5"
       }
     },
     {
       "scope": "meta.separator",
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#1d3e81"
+        "foreground": "#005cc5"
       },
       "name": "Meta.separator"
     },
@@ -346,43 +346,43 @@
       "name": "Output",
       "scope": "meta.output",
       "settings": {
-        "foreground": "#1d3e81"
+        "foreground": "#005cc5"
       }
     },
     {
       "scope" : "brackethighlighter.tag, brackethighlighter.curly, brackethighlighter.round, brackethighlighter.square, brackethighlighter.angle, brackethighlighter.quote",
       "settings" : {
-        "foreground" : "#595e62"
+        "foreground" : "#586069"
       }
     },
     {
       "scope" : "brackethighlighter.unmatched",
       "settings" : {
-        "foreground" : "#b52a1d"
+        "foreground" : "#b31d28"
       }
     },
     {
       "scope" : "sublimelinter.mark.error",
       "settings" : {
-        "foreground" : "#b52a1d"
+        "foreground" : "#b31d28"
       }
     },
     {
       "scope" : "sublimelinter.mark.warning",
       "settings" : {
-        "foreground" : "#ed6a43"
+        "foreground" : "#e36209"
       }
     },
     {
       "scope" : "sublimelinter.gutter-mark",
       "settings" : {
-        "foreground" : "#c0c0c0"
+        "foreground" : "#959da5"
       }
     },
     {
       "scope" : "constant.other.reference.link, string.other.link",
       "settings" : {
-        "foreground" : "#183691",
+        "foreground" : "#032f62",
         "fontStyle" : "underline"
       }
     }


### PR DESCRIPTION
This updates the light syntax to use GitHub's new [color system](https://github.com/primer/primer-support/blob/master/lib/variables/color-system.scss). I didn't change any colors for any entities, only updated each to an equivalent hue in the updated palette (e.g. blues stay blue, reds stay red, etc.). The update gives everything a little more contrast to help with readability while better matching the colors that were updated on github.com recently.

Example:

![screen shot 2017-04-12 at 4 20 08 pm](https://cloud.githubusercontent.com/assets/6104/24977817/6941fe20-1f9c-11e7-9a6f-c166d083b927.png)

/cc @jonrohan As you know, we've tested this out internally and I believe we're ready to package this up to update dotcom. I'd :heart: any help with the logistics and I'm happy to do as much of the work as possible if you can point me in the right direction.