### PR TITLE
Move the bracket matcher up in the index

### DIFF
--- a/lib/templates/atom/editor.less
+++ b/lib/templates/atom/editor.less
@@ -21,6 +21,7 @@ atom-text-editor {
   .bracket-matcher .region {
     border-bottom: 1px solid @syntax-cursor-color;
     box-sizing: border-box;
+    z-index: 1;
   }
 
   .invisible-character {


### PR DESCRIPTION
This fixes https://github.com/primer/github-syntax-theme-generator/issues/41 by moving the `bracket-matcher` up in the index order. The `cursor-line` was given a highlight color and visible above the bracket-matcher.

@lee-dohm would a fix in this way be problematic in any way?