### PR TITLE
Writing the language css to the root atom text editor

### DIFF
--- a/lib/adapters/atom.js
+++ b/lib/adapters/atom.js
@@ -37,5 +37,5 @@ module.exports = (theme) => {
 
   fs.writeFileSync(`./build/atom/${theme.filename}/syntax-variables.less`, syntaxVariables)
   fs.writeFileSync(`./build/atom/${theme.filename}/editor.less`, editor)
-  fs.writeFileSync(`./build/atom/${theme.filename}/languages.less`, languages)
+  fs.writeFileSync(`./build/atom/${theme.filename}/languages.less`, `atom-text-editor {${languages}}`)
 }


### PR DESCRIPTION
This writes all the `languages.less` selectors into the root `atom-text-editor` which will help with specificity.

The result Less looks like this.

```less
atom-text-editor {
    .syntax--comment,
    .syntax--punctuation.syntax--definition.syntax--comment,
    .syntax--string.syntax--comment {
      color: #959da5;
    }
}
```

fixes https://github.com/primer/github-syntax-theme-generator/issues/30

