### PR TITLE
Fix variable color in php

### DIFF
--- a/lib/themes/dark.json
+++ b/lib/themes/dark.json
@@ -129,7 +129,7 @@
       "name" : "Variable"
     },
     {
-      "scope": "variable.other",
+      "scope": "variable.other, variable.php",
       "settings" : {
         "foreground" : "#f6f8fa"
       }

--- a/lib/themes/light.json
+++ b/lib/themes/light.json
@@ -130,7 +130,7 @@
       "name": "Variable"
     },
     {
-      "scope": "variable.other",
+      "scope": "variable.other, variable.php",
       "settings": {
         "foreground": "#24292e"
       }


### PR DESCRIPTION
Fixed the variable color in PHP to match GitHub's variable color.

Atom on the left and GitHub on the right:

<img width="1206" alt="screen shot 2017-06-15 at 10 34 07 am" src="https://user-images.githubusercontent.com/499192/27172665-52651ac4-51b6-11e7-9597-79f6b8fd066e.png">
