### PR TITLE
Fix jsdoc color

### DIFF
--- a/lib/themes/dark.json
+++ b/lib/themes/dark.json
@@ -51,7 +51,7 @@
       "settings": {}
     },
     {
-      "scope" : "entity, entity.name",
+      "scope" : "entity, entity.name, jsdoc",
       "settings" : {
         "fontStyle" : "",
         "foreground" : "#b392f0"

--- a/lib/themes/light.json
+++ b/lib/themes/light.json
@@ -52,7 +52,7 @@
       "settings": {}
     },
     {
-      "scope": "entity, entity.name",
+      "scope": "entity, entity.name, jsdoc",
       "settings": {
         "fontStyle": "",
         "foreground": "#6f42c1"


### PR DESCRIPTION
Fixed the jsdoc color which shows blue color for `string` but purple (the correct color) for `array`. With this fix all jsdoc items are purple.