### PR TITLE
fix: invalid selector causes a whole ignorance

### DIFF
--- a/lib/templates/codemirror.scss
+++ b/lib/templates/codemirror.scss
@@ -32,7 +32,11 @@
   div.CodeMirror-selected,
   .CodeMirror-line::selection,
   .CodeMirror-line > span::selection,
-  .CodeMirror-line > span > span::selection,
+  .CodeMirror-line > span > span::selection {
+    background: ${selection};
+  }
+  
+  div.CodeMirror-selected,
   .CodeMirror-line::-moz-selection,
   .CodeMirror-line > span::-moz-selection,
   .CodeMirror-line > span > span::-moz-selection {


### PR DESCRIPTION
`::-moz-selection` is not recognized by Chrome, leading to the whole selector generated being invalid and ignored. Splitting them into 2 parts should resolve this issue.

Further optimizations can be made to let these two parts DRY.